### PR TITLE
Huffman bug correction

### DIFF
--- a/src/Huffman.h
+++ b/src/Huffman.h
@@ -83,8 +83,7 @@ namespace bw {
         public:
             void static compress(istreambin &streamin, ostreambin &streamout) {
                 // read the input
-                std::istreambuf_iterator<char> eos;
-                std::string input(std::istreambuf_iterator<char>(*(streamin.getStream())), eos);
+                std::string input(std::istreambuf_iterator<char>(*(streamin.getStream())), {});
                 //std::getline(*streamin.getStream(), input, (char) std::cin.eof());
 
                 // tabulate frequency counts

--- a/src/Huffman.h
+++ b/src/Huffman.h
@@ -57,6 +57,7 @@ namespace bw {
 
     };
     typedef std::shared_ptr<Node> Node_ptr;
+    typedef unsigned char UCHAR;
 
 
     bool operator<(const bw::Node_ptr &a, const bw::Node_ptr &b);
@@ -82,15 +83,16 @@ namespace bw {
         public:
             void static compress(istreambin &streamin, ostreambin &streamout) {
                 // read the input
-                std::string input;
-                std::getline(*streamin.getStream(), input, (char) std::cin.eof());
+                std::istreambuf_iterator<char> eos;
+                std::string input(std::istreambuf_iterator<char>(*(streamin.getStream())), eos);
+                //std::getline(*streamin.getStream(), input, (char) std::cin.eof());
 
                 // tabulate frequency counts
                 std::vector<int> freq(R);
                 for (int i = 0; i < input.size(); i++)
                 {
-                    assert(input[i] >= 0);
-                    freq[input[i]]++;
+                    assert(((UCHAR)input[i]) >= 0);
+                    freq[((UCHAR)input[i])]++;
                 }
 
                 // build Huffman trie
@@ -109,7 +111,7 @@ namespace bw {
 
                 // use Huffman code to encode input
                 for (int i = 0; i < input.size(); i++) {
-                    std::string code = st[input[i]];
+                    std::string code = st[((UCHAR)input[i])];
                     for (int j = 0; j < code.size(); j++) {
                         if (code.at(j) == '0') {
                             streamout.write(false);

--- a/src/HuffmanMain.cpp
+++ b/src/HuffmanMain.cpp
@@ -100,8 +100,7 @@ int main(int argc, char** argv)
         {
 
             bw::ostreambin streamout(&std::cout);
-            std::string s;
-            std::getline(std::cin, s, (char) std::cin.eof());
+            std::string s(std::istreambuf_iterator<char>(std::cin), {});
             std::stringstream in(s);
             bw::istreambin streamin(&in);
             bw::Huffman::expand(streamin, streamout);


### PR DESCRIPTION
Last merge has caused an bug in the Huffman algorithm because of the mode of reading the stream and the signed char internal type of std::string
