### PR TITLE
Add missing #include <memory>

### DIFF
--- a/src/MoveToFront.h
+++ b/src/MoveToFront.h
@@ -5,6 +5,7 @@
 #include <vector>
 #include <iostream>
 #include <sstream>
+#include <memory>
 
 namespace bw
 {


### PR DESCRIPTION
Fixes:

    In file included from .../src/MoveToFront.cpp:1:0:
    .../src/MoveToFront.h: In static member function ‘static void bw::MoveToFront::encode(std::istream&, std::ostream&)’:
    .../src/MoveToFront.h:30:29: error: ‘shared_ptr’ is not a member of ‘std’